### PR TITLE
Implement Phase 3 AJAX creation

### DIFF
--- a/public/api/create_order.php
+++ b/public/api/create_order.php
@@ -1,0 +1,80 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+if (!isset($_SESSION['UserID'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+require_once __DIR__ . '/../../src/Database.php';
+$pdo = Database::connect();
+
+$productionNumber = $_POST['ProductionNumber'] ?? '';
+$emptyTube = $_POST['EmptyTubeNumber'] ?? '';
+$projectID = $_POST['ProjectID'] ?? null;
+$modelID = $_POST['ModelID'] ?? null;
+
+$error = '';
+
+if (!$productionNumber) {
+    $error = 'Production Number is required';
+} else {
+    $stmt = $pdo->prepare('SELECT COUNT(*) FROM ProductionOrders WHERE ProductionNumber = ?');
+    $stmt->execute([$productionNumber]);
+    if ($stmt->fetchColumn() > 0) {
+        $error = 'Production Number already exists';
+    }
+}
+
+if ($error) {
+    http_response_code(422);
+    echo json_encode(['error' => $error]);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('INSERT INTO ProductionOrders (ProductionNumber, EmptyTubeNumber, ProjectID, ModelID) VALUES (?, ?, ?, ?)');
+    $stmt->execute([$productionNumber, $emptyTube, $projectID, $modelID]);
+
+    if (!empty($_POST['liner'])) {
+        $luStmt = $pdo->prepare('INSERT INTO MC02_LinerUsage (ProductionNumber, LinerType, LinerBatchNumber, Remarks) VALUES (?, ?, ?, ?)');
+        foreach ($_POST['liner'] as $liner) {
+            if (!$liner['LinerType']) continue;
+            $luStmt->execute([$productionNumber, $liner['LinerType'], $liner['LinerBatchNumber'], $liner['Remarks']]);
+        }
+    }
+
+    if (!empty($_POST['log'])) {
+        $logStmt = $pdo->prepare('INSERT INTO MC02_ProcessLog (ProductionNumber, SequenceNo, ProcessStepName, DatePerformed, Result, Operator_UserID, Remarks, ControlValue, ActualMeasuredValue) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        foreach ($_POST['log'] as $log) {
+            $logStmt->execute([
+                $productionNumber,
+                $log['SequenceNo'],
+                $log['ProcessStepName'],
+                $log['DatePerformed'] ?: null,
+                $log['Result'] ?: null,
+                $log['Operator_UserID'] ?: null,
+                $log['Remarks'] ?: null,
+                $log['ControlValue'] ?: null,
+                $log['ActualMeasuredValue'] ?: null,
+            ]);
+        }
+    }
+
+    $pdo->commit();
+    echo json_encode(['success' => true, 'production_number' => $productionNumber]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => 'Error creating order']);
+}
+?>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -123,3 +123,7 @@ body { padding-top: 70px; }
 .navbar {
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
 }
+
+#loading-overlay {
+    backdrop-filter: blur(2px);
+}

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1,1 +1,29 @@
-// Basic JS placeholder
+function showToast(message, type = 'success') {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+    const wrapper = document.createElement('div');
+    const variant = type === 'error' ? 'danger' : type;
+    wrapper.className = `toast align-items-center text-bg-${variant}`;
+    wrapper.setAttribute('role', 'alert');
+    wrapper.setAttribute('aria-live', 'assertive');
+    wrapper.setAttribute('aria-atomic', 'true');
+    wrapper.innerHTML = `
+        <div class="d-flex">
+            <div class="toast-body">${message}</div>
+            <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>`;
+    container.appendChild(wrapper);
+    const toast = new bootstrap.Toast(wrapper, { delay: 3000 });
+    toast.show();
+    wrapper.addEventListener('hidden.bs.toast', () => wrapper.remove());
+}
+
+function showLoading() {
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) overlay.classList.remove('d-none');
+}
+
+function hideLoading() {
+    const overlay = document.getElementById('loading-overlay');
+    if (overlay) overlay.classList.add('d-none');
+}

--- a/public/create_order.php
+++ b/public/create_order.php
@@ -87,7 +87,7 @@ include 'templates/header.php';
             </div>
         <?php endif; ?>
 
-        <form method="post">
+        <form method="post" id="create-order-form">
             <!-- Basic Information Card -->
             <div class="card mb-4">
                 <div class="card-header">
@@ -324,29 +324,47 @@ function removeLinerRow(button) {
 
 // Form validation
 document.addEventListener('DOMContentLoaded', function() {
-    const form = document.querySelector('form');
+    const form = document.getElementById('create-order-form');
+    if (!form) return;
+
     form.addEventListener('submit', function(e) {
-        const productionNumber = document.querySelector('input[name="ProductionNumber"]').value.trim();
-        const projectId = document.querySelector('select[name="ProjectID"]').value;
-        const modelId = document.querySelector('select[name="ModelID"]').value;
-        
+        e.preventDefault();
+        const productionNumber = form.querySelector('input[name="ProductionNumber"]').value.trim();
+        const projectId = form.querySelector('select[name="ProjectID"]').value;
+        const modelId = form.querySelector('select[name="ModelID"]').value;
+
         if (!productionNumber) {
-            e.preventDefault();
-            alert('Production Number is required.');
+            showToast('Production Number is required', 'error');
             return;
         }
-        
         if (!projectId) {
-            e.preventDefault();
-            alert('Please select a Project.');
+            showToast('Please select a Project', 'error');
             return;
         }
-        
         if (!modelId) {
-            e.preventDefault();
-            alert('Please select a Model.');
+            showToast('Please select a Model', 'error');
             return;
         }
+
+        showLoading();
+        fetch('api/create_order.php', {
+            method: 'POST',
+            body: new FormData(form)
+        })
+        .then(r => r.json())
+        .then(data => {
+            hideLoading();
+            if (data.success) {
+                showToast('Order created successfully!', 'success');
+                window.location.href = 'view_order.php?pn=' + encodeURIComponent(data.production_number);
+            } else {
+                showToast(data.error || 'Error creating order', 'error');
+            }
+        })
+        .catch(() => {
+            hideLoading();
+            showToast('Error creating order', 'error');
+        });
     });
 });
 </script>

--- a/public/templates/header.php
+++ b/public/templates/header.php
@@ -10,6 +10,10 @@
     <link href="assets/css/app.css" rel="stylesheet">
 </head>
 <body>
+<div id="loading-overlay" class="position-fixed top-0 start-0 w-100 h-100 bg-white bg-opacity-50 d-none align-items-center justify-content-center" style="z-index:1055;">
+    <div class="spinner-border text-primary" role="status"></div>
+</div>
+<div id="toast-container" class="position-fixed top-0 end-0 p-3" style="z-index:1100;"></div>
 <?php include __DIR__ . '/navigation.php'; ?>
 
 <?php if (isset($breadcrumbs) && !empty($breadcrumbs)): ?>


### PR DESCRIPTION
## Summary
- add API endpoint for creating orders via AJAX
- show toast notifications and loading overlay in header
- hook create_order.php form to async API with validation
- centralize helper JS for toasts/loading
- style overlay in app CSS

## Testing
- `php -l public/api/create_order.php`
- `php -l public/create_order.php`
- `php -l public/templates/header.php`

------
https://chatgpt.com/codex/tasks/task_e_6842adf287c4832f88012c7bc07ac57f